### PR TITLE
more ergonomic makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Georgia Tech’s “Toddler’s Bottle” exercises are very close to the ideal 
 
 So, “Where do I start?” — there really is no straightforward solution, but hopefully this guide will get you going. Good luck! You can find the rendered PDF in the "releases" section.
 
+$ Getting the PDF
+
+Head on to the "releases" section to get the latest version of the PDF.
+
+If you'd rather make the PDF from source: clone or download the repository and from your local repo copy run `make booklet`. If prompted for missing latex dependencies, install them.
+
 # Changelog
 
 2021-04-14: Minor grammar fix, make the rendered pdf a release rather than keeping it inside the repo like a plebe.

--- a/makefile
+++ b/makefile
@@ -1,5 +1,6 @@
 booklet: a_first_introduction_to_system_exploitation.tex demos
 	pdflatex a_first_introduction_to_system_exploitation.tex
+	pdflatex a_first_introduction_to_system_exploitation.tex #for table of contents
 
 demos: fd_demo hash_demo xxd_demo
 
@@ -11,5 +12,10 @@ fd_demo: ./code/fd_demo.c
 
 xxd_demo: ./code/xxd_demo
 	xxd ./code/xxd_demo > ./code/xxd_demo.hex
+
+clean: 
+	rm -f *.aux *.log *.out *.toc *.pdf
+
+all: booklet
 
 


### PR DESCRIPTION
* Add "clean" to makefile
* Cause makefile to run pdflatex twice, fixing bug with missing table of contents
* Better explain how to use makefile in the readme